### PR TITLE
Fix for Ch-4 Dockerfile

### DIFF
--- a/Chapter04/docker/Dockerfile
+++ b/Chapter04/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY go.* ./
 RUN go mod download
 
 # Copy local code to the container image.
-COPY .. ./
+COPY . ./
 
 # Build the binary.
 RUN go build -v -o monolith ./cmd/mallbots


### PR DESCRIPTION
This problem does not allow the successful containers built: ...
Step 5/11 : COPY .. ./
...

Logs: 

COPY failed: forbidden path outside the build context: .. () ERROR: Service 'monolith' failed to build : Build failed

The solution is shown below:
...
COPY . ./
...