### PR TITLE
feat: remove unnecessary switch statement

### DIFF
--- a/Chapter03/baskets/internal/domain/basket.go
+++ b/Chapter03/baskets/internal/domain/basket.go
@@ -26,12 +26,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketOpen, BasketCancelled, BasketCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 type Basket struct {

--- a/Chapter04/baskets/internal/domain/basket_status.go
+++ b/Chapter04/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter05/baskets/internal/domain/basket_status.go
+++ b/Chapter05/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter06/baskets/internal/domain/basket_status.go
+++ b/Chapter06/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter07/baskets/internal/domain/basket_status.go
+++ b/Chapter07/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter08/baskets/internal/domain/basket_status.go
+++ b/Chapter08/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter09/baskets/internal/domain/basket_status.go
+++ b/Chapter09/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter10/baskets/internal/domain/basket_status.go
+++ b/Chapter10/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter11/baskets/internal/domain/basket_status.go
+++ b/Chapter11/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {

--- a/Chapter12/baskets/internal/domain/basket_status.go
+++ b/Chapter12/baskets/internal/domain/basket_status.go
@@ -10,12 +10,7 @@ const (
 )
 
 func (s BasketStatus) String() string {
-	switch s {
-	case BasketIsOpen, BasketIsCanceled, BasketIsCheckedOut:
-		return string(s)
-	default:
-		return ""
-	}
+	return string(s)
 }
 
 func ToBasketStatus(status string) BasketStatus {


### PR DESCRIPTION
Hi! the switch statement from the basket string method was unnecessary. The test cases I did were the following:

```go
package domain

import (
	"testing"

	"github.com/stretchr/testify/assert"
)

func TestBasketString(t *testing.T) {
	// arrange
	cases := []struct {
		elem   BasketStatus
		expect string
	}{
		{
			BasketUnknown,
			"",
		},
		{
			BasketOpen,
			"open",
		},
		{
			BasketCancelled,
			"cancelled",
		},
		{
			BasketCheckedOut,
			"checked_out",
		},
	}
	for _, tt := range cases {
		// act
		actual := tt.elem.String()
		// assert
		assert.Equal(t, tt.expect, actual)
	}
}
```
p.d: Great Book!